### PR TITLE
Parameterize VM URL in spinUpVm.py

### DIFF
--- a/Anti-Trade-Spam-Permalocked/Config-and-Setup/spinUpVm.py
+++ b/Anti-Trade-Spam-Permalocked/Config-and-Setup/spinUpVm.py
@@ -1,3 +1,15 @@
+import os
+import sys
 import requests
+
+url = os.getenv("DESTINATION_URL")
+if len(sys.argv) > 1:
+    url = sys.argv[1]
+
+if not url:
+    raise SystemExit(
+        "Usage: DESTINATION_URL=<url> python spinUpVm.py [url]"
+    )
+
 data = {"info": "hello from VM1"}
-requests.post("http://<VM2_PUBLIC_IP>:5000/receive", json=data)
+requests.post(url, json=data)


### PR DESCRIPTION
## Summary
- allow configuring URL via command line argument or environment variable
- add missing newline at the end of `spinUpVm.py`

## Testing
- `python -m py_compile Anti-Trade-Spam-Permalocked/Config-and-Setup/spinUpVm.py`

------
https://chatgpt.com/codex/tasks/task_e_68414534771c8324b8b3da31d898bcb5